### PR TITLE
Fix newline in DB __init__

### DIFF
--- a/DB/__init__.py
+++ b/DB/__init__.py
@@ -1,2 +1,2 @@
 from .database import engine, SessionLocal, Base
-from .models import User, UserSettings, Conversation, Message, Subscription 
+from .models import User, UserSettings, Conversation, Message, Subscription


### PR DESCRIPTION
## Summary
- ensure DB `__init__` has no trailing spaces and ends with a newline

## Testing
- `PYTHONPATH=. pytest -q`